### PR TITLE
Fix abstract sprite setup

### DIFF
--- a/engine/src/game-object/game-object.ts
+++ b/engine/src/game-object/game-object.ts
@@ -106,7 +106,7 @@ export abstract class GameObject<Sprite = unknown, Body extends GameObjectBody =
      *
      * Meant to be overridden.
      */
-    public abstract setUpSprite(pixi: typeof PIXI, container: PIXI.Container): Sprite;
+    public setUpSprite?(pixi: typeof PIXI, container: PIXI.Container): Sprite;
 
     /**
      * If this GameObject needs any physics bodies,


### PR DESCRIPTION
I accidentally left `setUpSprite` as abstract, which causes some problems.

It should be concretely defined as `undefined` on the base `GameObject`.