### PR TITLE
Fix style in lint rule

### DIFF
--- a/engine/lint-rules/spaceInCurlyBracketsRule.js
+++ b/engine/lint-rules/spaceInCurlyBracketsRule.js
@@ -1,4 +1,4 @@
-const Lint = require("tslint");
+const Lint = require('tslint');
 
 const leadingFailureString = 'Curly brackets must contain a leading space.';
 const trailingFailureString = 'Curly brackets must contain a trailing space.';
@@ -13,17 +13,13 @@ class SpaceInCurlyBracketsWalker extends Lint.RuleWalker {
     _handleCurlyBrackets(node) {
         const contents = node.getText();
         
-        if (
-            contents !== "{}" && (contents.slice(1, 2) !== " " && contents.slice(1, 2) !== "\n")
-        ) {
-            const fix = new Lint.Replacement(node.getStart(), 1, "{ ");
+        if (contents !== '{}' && (contents.slice(1, 2) !== ' ' && contents.slice(1, 2) !== '\n')) {
+            const fix = new Lint.Replacement(node.getStart(), 1, '{ ');
             this.addFailure(this.createFailure(node.getStart(), 1, leadingFailureString, fix));
         }
         
-        if (
-            contents !== "{}" && (contents.slice(-2, -1) !== " " && contents.slice(-2, -1) !== "\n")
-        ) {
-            const fix = new Lint.Replacement(node.getEnd() - 1, 1, " }");
+        if (contents !== '{}' && (contents.slice(-2, -1) !== ' ' && contents.slice(-2, -1) !== '\n')) {
+            const fix = new Lint.Replacement(node.getEnd() - 1, 1, ' }');
             this.addFailure(this.createFailure(node.getEnd() - 1, 1, trailingFailureString, fix));
         }
     }

--- a/test-games/slippery-racing/lint-rules/spaceInCurlyBracketsRule.js
+++ b/test-games/slippery-racing/lint-rules/spaceInCurlyBracketsRule.js
@@ -1,4 +1,4 @@
-const Lint = require("tslint");
+const Lint = require('tslint');
 
 const leadingFailureString = 'Curly brackets must contain a leading space.';
 const trailingFailureString = 'Curly brackets must contain a trailing space.';
@@ -13,17 +13,13 @@ class SpaceInCurlyBracketsWalker extends Lint.RuleWalker {
     _handleCurlyBrackets(node) {
         const contents = node.getText();
         
-        if (
-            contents !== "{}" && (contents.slice(1, 2) !== " " && contents.slice(1, 2) !== "\n")
-        ) {
-            const fix = new Lint.Replacement(node.getStart(), 1, "{ ");
+        if (contents !== '{}' && (contents.slice(1, 2) !== ' ' && contents.slice(1, 2) !== '\n')) {
+            const fix = new Lint.Replacement(node.getStart(), 1, '{ ');
             this.addFailure(this.createFailure(node.getStart(), 1, leadingFailureString, fix));
         }
         
-        if (
-            contents !== "{}" && (contents.slice(-2, -1) !== " " && contents.slice(-2, -1) !== "\n")
-        ) {
-            const fix = new Lint.Replacement(node.getEnd() - 1, 1, " }");
+        if (contents !== '{}' && (contents.slice(-2, -1) !== ' ' && contents.slice(-2, -1) !== '\n')) {
+            const fix = new Lint.Replacement(node.getEnd() - 1, 1, ' }');
             this.addFailure(this.createFailure(node.getEnd() - 1, 1, trailingFailureString, fix));
         }
     }

--- a/test-games/template-typed-game/lint-rules/spaceInCurlyBracketsRule.js
+++ b/test-games/template-typed-game/lint-rules/spaceInCurlyBracketsRule.js
@@ -1,4 +1,4 @@
-const Lint = require("tslint");
+const Lint = require('tslint');
 
 const leadingFailureString = 'Curly brackets must contain a leading space.';
 const trailingFailureString = 'Curly brackets must contain a trailing space.';
@@ -13,17 +13,13 @@ class SpaceInCurlyBracketsWalker extends Lint.RuleWalker {
     _handleCurlyBrackets(node) {
         const contents = node.getText();
         
-        if (
-            contents !== "{}" && (contents.slice(1, 2) !== " " && contents.slice(1, 2) !== "\n")
-        ) {
-            const fix = new Lint.Replacement(node.getStart(), 1, "{ ");
+        if (contents !== '{}' && (contents.slice(1, 2) !== ' ' && contents.slice(1, 2) !== '\n')) {
+            const fix = new Lint.Replacement(node.getStart(), 1, '{ ');
             this.addFailure(this.createFailure(node.getStart(), 1, leadingFailureString, fix));
         }
         
-        if (
-            contents !== "{}" && (contents.slice(-2, -1) !== " " && contents.slice(-2, -1) !== "\n")
-        ) {
-            const fix = new Lint.Replacement(node.getEnd() - 1, 1, " }");
+        if (contents !== '{}' && (contents.slice(-2, -1) !== ' ' && contents.slice(-2, -1) !== '\n')) {
+            const fix = new Lint.Replacement(node.getEnd() - 1, 1, ' }');
             this.addFailure(this.createFailure(node.getEnd() - 1, 1, trailingFailureString, fix));
         }
     }


### PR DESCRIPTION
This fixes the double quotes and the unnecessary newlines in the lint rule files.

These files should be replaced with a single one somewhere eventually, but I'm not sure a good way to do that, so we can worry about that later.

Fixes #58