### PR TITLE
Make AnyAmountOf return readonly arrays

### DIFF
--- a/engine/src/util/as-array.ts
+++ b/engine/src/util/as-array.ts
@@ -1,14 +1,14 @@
 /**
  * An array of `T`, a single `T`, or `undefined`.
  */
-export type AnyAmountOf<T> = undefined | T | T[];
+export type AnyAmountOf<T> = undefined | T | readonly T[];
 
 /**
  * Takes `undefined`, a `T`, or an array of `T`,
  * and returns an array containing any `T` passed to it.
  */
-export function asArray<T>(value: AnyAmountOf<T>): T[] {
+export function asArray<T>(value: AnyAmountOf<T>): readonly T[] {
     if (Array.isArray(value)) { return value; }
-    if (value) { return [value]; }
+    if (value) { return [value as T]; }
     return [];
 }


### PR DESCRIPTION
Fixes #60

This just makes the arrays in AnyAmountOf readonly.

Modifying the returned array might or might not modify the original, so it's better the return type is readonly. This lets the argument be readonly, which makes it easier to work with.