### PR TITLE
Fix type of createObject

### DIFF
--- a/engine/src/game-object/game-object.ts
+++ b/engine/src/game-object/game-object.ts
@@ -44,8 +44,8 @@ export type GameObjectSprite = AnyAmountOf<PIXI.DisplayObject>;
  * The superclass of any objects that appear in the game.
  */
 export abstract class GameObject<
-    Sprite extends GameObjectSprite = undefined,
-    Body extends GameObjectBody = undefined
+    Sprite extends GameObjectSprite = GameObjectSprite,
+    Body extends GameObjectBody = GameObjectBody
 > {
 
     /**

--- a/engine/src/game/game.ts
+++ b/engine/src/game/game.ts
@@ -35,11 +35,13 @@ export class Game {
      *
      * Any arguments after the first are passed to the GameObject subclass's constructor.
      */
-    public createObject<Subclass extends GameObject, Args extends readonly []>(
-        Class: new (...args: Args) => Subclass,
-        ...args: Args
-    ) {
-        const newObject = new Class(...args);
+    public createObject<
+        Subclass extends new (...args: any[]) => GameObject,
+    >(
+        Class: Subclass,
+        ...args: ConstructorParameters<Subclass>
+    ): InstanceType<Subclass> {
+        const newObject = new Class(...args) as InstanceType<Subclass>;
 
         if (this._physicsEngine) {
             newObject.physicsWorld = this._physicsEngine.world;

--- a/test-games/slippery-racing/src/game-objects/main-object.ts
+++ b/test-games/slippery-racing/src/game-objects/main-object.ts
@@ -8,23 +8,23 @@ import { SoccerBall } from './soccer-ball';
 export class MainObject extends GameObject {
 
     private generateCircle(center: Vector, size: number) {
-        (game.createObject as any)(Decoration, center, size + 460, 0x888888);
-        (game.createObject as any)(Decoration, center, size + 450, 0xd7d7d7);
-        (game.createObject as any)(Decoration, center, size + 300, 0x44bf4d);
-        (game.createObject as any)(Decoration, center, size + 10, 0x3e7242, true);
-        (game.createObject as any)(Decoration, center, size, 0x45824a);
+        game.createObject(Decoration, center, size + 460, 0x888888);
+        game.createObject(Decoration, center, size + 450, 0xd7d7d7);
+        game.createObject(Decoration, center, size + 300, 0x44bf4d);
+        game.createObject(Decoration, center, size + 10, 0x3e7242, true);
+        game.createObject(Decoration, center, size, 0x45824a);
     }
 
     private generateTireCircle(center: Vector, size: number, amount: number) {
         for (let i = 0; i < 360; i += 360 / amount) {
-            (game.createObject as any)(
+            game.createObject(
                 LooseTire,
                 center.plus(Vector.lengthAndDirection(size, Angle.degrees(i))),
             );
         }
 
         for (let i = 180 / amount; i < 360; i += 360 / amount) {
-            (game.createObject as any)(
+            game.createObject(
                 LooseTire,
                 center.plus(Vector.lengthAndDirection(size + 100, Angle.degrees(i))),
             );
@@ -40,8 +40,9 @@ export class MainObject extends GameObject {
         this.generateCircle(Vector.xy(1900, -2700), 150);
         this.generateCircle(Vector.xy(2900, -2400), 250);
 
-        const camera = (game.createObject as any)(Camera) as Camera;
-        (game.createObject as any)(
+        const camera = game.createObject(Camera);
+
+        game.createObject(
             Car,
             Vector.xy(-300, 0),
             {
@@ -57,7 +58,7 @@ export class MainObject extends GameObject {
         this.generateTireCircle(Vector.zero, 800, 24);
         this.generateTireCircle(Vector.xy(-2900, -2700), 300, 48);
 
-        (game.createObject as any)(
+        game.createObject(
             SoccerBall,
             Vector.xy(0, -1400),
         );


### PR DESCRIPTION
Fixes #59 

Previously, the `createObject` type was completely broken for anything with arguments.

This fixes that. It's got one unpleasant typecast, but it's pretty obviously correct. Calls can correctly infer generic arguments, so it's quite easy to use.