### PR TITLE
Teleport cars away when the player leaves

### DIFF
--- a/test-games/slippery-racing/src/game-objects/car.ts
+++ b/test-games/slippery-racing/src/game-objects/car.ts
@@ -97,6 +97,10 @@ export class Car extends GameObject {
         this.body.applyForce(sidewaysFriction);
     }
 
+    public remove() {
+        this.body.position = this.body.position.plus(Vector.xy(0, 100000));
+    }
+
 }
 game.registerClass(Car);
 

--- a/test-games/slippery-racing/src/game-objects/server.ts
+++ b/test-games/slippery-racing/src/game-objects/server.ts
@@ -1,4 +1,4 @@
-import { Angle, game, Server, Vector } from 'engine';
+import { Angle, game, Server, User, Vector } from 'engine';
 import { Car } from './car';
 import { Decoration } from './decoration';
 import { LooseTire } from './loose-tire';
@@ -53,6 +53,16 @@ export class SlipperServer extends Server {
         this.game().getWorld()!.gravity = { x: 0, y: 0, scale: 0 };
 
         this.start(+process.env.SLIPPERY_RACING_PORT!);
+    }
+
+    public onUserLeft(user: User) {
+        for (const child of this.children()) {
+            if (child.getOwner()?.id() === user.id()) {
+                if (child instanceof Car) {
+                    child.remove();
+                }
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Fixes #195.

Destroying things seems to be broken, currently, so for now cars are teleported away when the player leaves. If someone drives 100000 pixels up, they'll find the dead cars, but that's ok.