### PR TITLE
Allow all origins

### DIFF
--- a/engine/src/multiplayer/server.ts
+++ b/engine/src/multiplayer/server.ts
@@ -179,6 +179,7 @@ export class Server extends GameObject {
         if (!SocketIO || this._socketIOServer) { return; }
 
         this._socketIOServer = SocketIO(port);
+        this._socketIOServer.origins((req, callback) => { callback(null, true); });
         this._socketIOServer.on('connect', (socket) => {
             // this._userToSocket changes aren't queued,
             // to avoid using sockets that are dead.


### PR DESCRIPTION
This PR undoes the security fix all the other ones do. We should add an option to specify origins later, but it's not really necessary for games, and will cause programmers some issues.