### PR TITLE
Fix collisions

### DIFF
--- a/engine/src/game-loop/game-loop.ts
+++ b/engine/src/game-loop/game-loop.ts
@@ -217,13 +217,13 @@ export class GameLoop {
         };
 
         this._forEachObject((gameObjectA) => {
+            if (!gameObjectA.onCollision) { return; }
             this._forEachObject((gameObjectB) => {
                 if (gameObjectB === gameObjectA) {
                     return;
                 }
                 if (collides(gameObjectA, gameObjectB)) {
                     gameObjectA.onCollision && gameObjectA.onCollision(gameObjectB);
-                    gameObjectB.onCollision && gameObjectB.onCollision(gameObjectA);
                 }
             });
         });

--- a/engine/src/game-loop/game-loop.ts
+++ b/engine/src/game-loop/game-loop.ts
@@ -216,8 +216,8 @@ export class GameLoop {
             });
         };
 
-        this._gameObjects.forEach((gameObjectA) => {
-            this._gameObjects.forEach((gameObjectB) => {
+        this._forEachObject((gameObjectA) => {
+            this._forEachObject((gameObjectB) => {
                 if (gameObjectB === gameObjectA) {
                     return;
                 }


### PR DESCRIPTION
Previously collisions only checked the root objects, which wasn't very helpful. Now it loops through every object.

Tested with slippery racing.