### PR TITLE
Add server UUIDs

### DIFF
--- a/engine/src/multiplayer/client.ts
+++ b/engine/src/multiplayer/client.ts
@@ -138,7 +138,7 @@ export class Client extends GameObject {
             case MessageType.User: {
                 const { user, server } = JSON.parse(contents);
                 this._user = new User(user);
-                this._serverID = server;
+                this._serverID = this._serverID || server;
                 this.onRegistered?.();
                 return;
             }
@@ -204,7 +204,7 @@ export class Client extends GameObject {
     private _send(message: unknown, type: MessageType) {
         if (!this._socketIOClient) { return; }
 
-        this._socketIOClient.send(type, message);
+        this._socketIOClient.send(type, { message, server: this._serverID });
     }
 
     /**

--- a/engine/src/multiplayer/client.ts
+++ b/engine/src/multiplayer/client.ts
@@ -39,6 +39,13 @@ export class Client extends GameObject {
     private _user: User | undefined;
 
     /**
+     * The server the client thinks it is connected to.
+     *
+     * Used to detect if the server is changed, somehow.
+     */
+    private _serverID: string | undefined;
+
+    /**
      * Indicates if it is the client's turn to send an update.
      *
      * Set to false on sending an update,
@@ -128,10 +135,13 @@ export class Client extends GameObject {
         }
 
         switch (type) {
-            case MessageType.User:
-                this._user = new User(contents);
+            case MessageType.User: {
+                const { user, server } = JSON.parse(contents);
+                this._user = new User(user);
+                this._serverID = server;
                 this.onRegistered?.();
                 return;
+            }
             case MessageType.String:
                 this.onMessage?.(contents);
                 return;

--- a/engine/src/multiplayer/server.ts
+++ b/engine/src/multiplayer/server.ts
@@ -1,4 +1,5 @@
 import type * as SocketIOForType from 'socket.io';
+import uuid = require('uuid');
 import { gameObjectBodyKey } from '../body/body';
 import {
     afterStepKey,
@@ -48,6 +49,14 @@ export class Server extends GameObject {
     private readonly _users: Set<User> = new Set();
 
     private readonly _shouldUpdateUser = new Map<string, boolean>();
+
+    /**
+     * A unique ID for this server.
+     *
+     * This way, if a client swaps servers somehow,
+     * it can be detected and ignored.
+     */
+    private readonly _serverID = uuid.v4();
 
     /**
      * An array of events yet to be processed.
@@ -187,7 +196,7 @@ export class Server extends GameObject {
             this._userToSocket.set(user.id(), socket);
             this._eventQueue.push({ type: ServerEventType.Connect, user });
 
-            this._send(user, user.id(), MessageType.User);
+            this._send(user, JSON.stringify({ user: user.id(), server: this._serverID }), MessageType.User);
 
             socket.on('message', (type: unknown, contents: unknown) => {
                 this._eventQueue.push({ type: ServerEventType.Message, user, message: { type, contents } });


### PR DESCRIPTION
This adds UUIDs to servers, and checks them on messages.

This way, the server won't crash when you restart it & a client is still live.

Fixes #275